### PR TITLE
fix: Search Method

### DIFF
--- a/arc-crm/src/pages/CompanyPage.tsx
+++ b/arc-crm/src/pages/CompanyPage.tsx
@@ -158,6 +158,7 @@ function CompanyPage() {
             return;
         }
 
+        setLoading(true);
         try {
             const params = new URLSearchParams();
             if (searchCompanyName) params.append('companyName', searchCompanyName);
@@ -180,6 +181,8 @@ function CompanyPage() {
             setError(null);
         } catch (err) {
             setError((err as Error).message);
+        } finally {
+            setLoading(false);
         }
     };
 

--- a/arc-crm/src/pages/CompanyUserPage.tsx
+++ b/arc-crm/src/pages/CompanyUserPage.tsx
@@ -218,6 +218,8 @@ function CompanyUserPage() {
             setError(null);
         } catch (err) {
             setError((err as Error).message);
+        } finally {
+            setLoading(false);
         }
     };
 

--- a/arc-crm/src/pages/ContactHistoryPage.tsx
+++ b/arc-crm/src/pages/ContactHistoryPage.tsx
@@ -159,6 +159,7 @@ function ContactHistoryPage() {
             return;
         }
 
+        setLoading(true);
         try {
             const params = new URLSearchParams();
             if (searchCompanyName) params.append('companyName', searchCompanyName);
@@ -184,6 +185,8 @@ function ContactHistoryPage() {
             setError(null);
         } catch (err) {
             setError((err as Error).message);
+        } finally {
+            setLoading(false);
         }
     };
 

--- a/arc-crm/src/pages/DealPage.tsx
+++ b/arc-crm/src/pages/DealPage.tsx
@@ -199,6 +199,7 @@ function DealPage() {
             return;
         }
 
+        setLoading(true);
         try {
             const params = new URLSearchParams();
             if (searchCompanyName.trim()) params.append('companyName', searchCompanyName);
@@ -223,6 +224,8 @@ function DealPage() {
             setError(null);
         } catch (err) {
             setError((err as Error).message);
+        } finally {
+            setLoading(false);
         }
     };
 


### PR DESCRIPTION
기존 CompanyUserPage에서 setLoading이 해제되는 구문이 없어 영원히 로딩 되는 문제 발견
- setLoading(false) 구문 추가하여 해결

CompanyPage, DealPage, ContactHistoryPage의 search Method에 setLoading을 추가하여 타 페이지와 마찬가지로 사용자의 네트워크 상황에 따른 로딩 중. 알림이 뜨도록 변경